### PR TITLE
Work around smif #316

### DIFF
--- a/models/transport/run.py
+++ b/models/transport/run.py
@@ -166,10 +166,16 @@ class BaseTransportWrapper(SectorModel):
         population.to_csv(population_filepath)
 
         # GVA
-        base_gva = data_handle.get_base_timestep_data("gva").as_df().reset_index()
+        base_da = data_handle.get_base_timestep_data("gva")
+        base_gva = base_da.as_df().reset_index()
+        # work around smif not overriding source output name
+        base_gva = base_gva.rename(columns={base_da.name: 'gva'})
         base_gva['year'] = data_handle.base_timestep
 
-        current_gva = data_handle.get_data("gva").as_df().reset_index()
+        current_da = data_handle.get_data("gva")
+        current_gva = current_da.as_df().reset_index()
+        # work around smif not overriding source output name
+        current_gva = current_gva.rename(columns={current_da.name: 'gva'})
         current_gva['year'] = data_handle.current_timestep
 
         if data_handle.current_timestep != data_handle.base_timestep:


### PR DESCRIPTION
As reported by @roseDickinson - `transport_full_test`  fails with:

```
(nismod) vagrant@vagrant:/vagrant$ smif run transport_full_test
/home/vagrant/nismod/lib/python3.5/site-packages/smif/data_layer/file/file_metadata_store.py:135: FionaDeprecationWarning: Use fiona.Env() instead.
  with fiona.drivers():
/home/vagrant/nismod/lib/python3.5/site-packages/pandas/core/frame.py:3940: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
  errors=errors)
Traceback (most recent call last):
  File "/home/vagrant/nismod/lib/python3.5/site-packages/pandas/core/indexes/base.py", line 2656, in get_loc
    return self._engine.get_loc(key)
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 132, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1601, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1608, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'gva'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vagrant/nismod/lib/python3.5/site-packages/smif/controller/scheduler.py", line 178, in add
    self._run(job_graph, job_graph_id)
  File "/home/vagrant/nismod/lib/python3.5/site-packages/smif/controller/scheduler.py", line 249, in _run
    model.simulate(data_handle)
  File "models/transport/run.py", line 75, in simulate
    self._set_inputs(data)
  File "models/transport/run.py", line 184, in _set_inputs
    index='year', columns=colname, values='gva'
  File "/home/vagrant/nismod/lib/python3.5/site-packages/pandas/core/frame.py", line 5628, in pivot
    return pivot(self, index=index, columns=columns, values=values)
  File "/home/vagrant/nismod/lib/python3.5/site-packages/pandas/core/reshape/pivot.py", line 386, in pivot
    indexed = data._constructor_sliced(data[values].values,
  File "/home/vagrant/nismod/lib/python3.5/site-packages/pandas/core/frame.py", line 2927, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/home/vagrant/nismod/lib/python3.5/site-packages/pandas/core/indexes/base.py", line 2658, in get_loc
    return self._engine.get_loc(self._maybe_cast_indexer(key))
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 132, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 1601, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1608, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'gva'
KeyError: 'gva'
```

Related to nismod/smif#316