### PR TITLE
Move lad_uk_simplified to a generic location

### DIFF
--- a/config/dimensions/lad_uk_2016.yml
+++ b/config/dimensions/lad_uk_2016.yml
@@ -1,3 +1,3 @@
 name: lad_uk_2016
 description: Local Authority Districts (data from 2016, unchanged since 2009)
-elements: ../energy_demand/energy_demand_minimal/region_definitions/lad_2016_uk_simplified.shp
+elements: ../dimensions/lad_2016_uk_simplified.shp

--- a/provision/install_energy_demand.sh
+++ b/provision/install_energy_demand.sh
@@ -6,6 +6,9 @@ base_path=$1
 # Read model_version, remote_data, local_dir from config.ini
 eval "$(grep -A3 "\[energy-demand\]" $base_path/provision/config.ini | tail -n3)"
 
+# Copy lad_2016_uk_simplified.shp to a more general location as it is used by more than just energy_demand
+cp $base_path/data/energy_demand/energy_demand_minimal/region_definitions/lad_2016_uk_simplified.shp $base_path/data/dimensions/lad_2016_uk_simplified.shp
+
 # Install energy_demand
 pip install git+https://github.com/nismod/energy_demand.git@$model_version#egg=energy_demand --upgrade
 


### PR DESCRIPTION
This caused an issue when running the transport model in isolation on DAFNI. This allows DAFNI to inject the data file into a generic location while allowing NISMOD2 to continue working without DAFNI.