### PR TITLE
Move lads_gb_2016 to a generic location

### DIFF
--- a/config/dimensions/lad_gb_2016.yml
+++ b/config/dimensions/lad_gb_2016.yml
@@ -1,3 +1,3 @@
 name: lad_gb_2016
 description: Local Authority Districts (data from 2016, unchanged since 2009)
-elements: ../et_module/dimensions/lad_gb_2016.shp
+elements: ../dimensions/lad_gb_2016.shp

--- a/provision/install_et_module.sh
+++ b/provision/install_et_module.sh
@@ -8,3 +8,6 @@ eval "$(grep -A3 "\[et-module\]" $base_path/provision/config.ini | tail -n3)"
 
 # Install energy_demand
 pip install git+https://github.com/nismod/et_module.git@$model_version#egg=et_module --upgrade
+
+# Copy lad_gb_2016.shp to a more general location as it is used by more than just et_module
+cp $base_path/data/et_module/dimensions/lad_gb_2016.shp $base_path/data/dimensions/lad_gb_2016.shp


### PR DESCRIPTION
This caused an issue when running the transport model in isolation on DAFNI. This allows DAFNI to inject the data file into a generic location while allowing NISMOD2 to continue working without DAFNI.

