### PR TITLE
Use generic locations for sectors and enduses

### DIFF
--- a/config/dimensions/enduses.yml
+++ b/config/dimensions/enduses.yml
@@ -1,3 +1,3 @@
 name: enduses
 description: The categories by which energy is demanded
-elements: ../energy_demand/dimensions/enduses.csv
+elements: enduses.csv

--- a/config/dimensions/sectors.yml
+++ b/config/dimensions/sectors.yml
@@ -1,3 +1,3 @@
 name: sectors
 description: Industrial sectors
-elements: ../energy_demand/dimensions/sectors.csv
+elements: sectors.csv


### PR DESCRIPTION
I noticed that the .csv files in these Dimensions are actually in /data/dimension and stored in the github repo so changed the ymls to point to these files to remove the Transport model's dependency on Energy Demand data for these files.