### PR TITLE
Fix typo that causes no such file or directory

### DIFF
--- a/models/energy_supply/energy_supply.py
+++ b/models/energy_supply/energy_supply.py
@@ -225,7 +225,7 @@ class EnergySupplyWrapper(SectorModel):
 
         os.environ["ES_PATH"] = str(model_dir)
         self.logger.debug("\n\n***Running the Energy Supply Model***\n\n")
-        self.logger.debug(check_output(['mosel', 'exec', model_path]))
+        self.logger.debug(check_output(['model', 'exec', model_path]))
 
     def retrieve_outputs(self, data, now):
         """Retrieves results from the model


### PR DESCRIPTION
This typo in the logging message causes a 'No such file or directory' message 