### PR TITLE
Fix transport_full_test - transport_build_winslow

### DIFF
--- a/config/model_runs/transport_full_test.yml
+++ b/config/model_runs/transport_full_test.yml
@@ -12,6 +12,6 @@ decision_module: []
 strategies:
   - type: pre-specified-planning
     description: test interventions
-    filename: transport_build_winslow.csv
+    filename: transport_build_winslow
     model_name: transport
 stamp: ''


### PR DESCRIPTION
Fixes the following error when running transport_full_test:
`FileNotFoundError: [Errno 2] File ./data/strategies/transport_build_winslow.csv.csv does not exist: './data/strategies/transport_build_winslow.csv.csv'`